### PR TITLE
Remove `use_system_site_packages` in RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,5 @@
 python:
     version: 3.7
-    use_system_site_packages: true
     pip_install: true
     extra_requirements:
         - doc


### PR DESCRIPTION
ReadTheDocs deprecated and removed this parameter.  Assuming our `doc` optional requirements are complete, we shouldn't need system packages anyway, so it should be fine to just remove it from our config.