### PR TITLE
Drop py 3.6 testing; add 3.9/3.10/3.11 testing

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         env: ['-r requirements.txt']
 
     steps:


### PR DESCRIPTION
This PR drops 3.6 (which is EOL, and doesn't install easily anymore) from testing and adds 3.9, 3.10, and 3.11.  3.12 is coming out soon but doesn't have an official release yet.